### PR TITLE
fix(core): fix 6 bugs found in codebase audit

### DIFF
--- a/src/adapters/realtime.ts
+++ b/src/adapters/realtime.ts
@@ -1,12 +1,12 @@
-import { BaseAdapter } from './base';
-import type { AnalyticsEngineDataPoint } from '../types/realtime';
+import { BaseAdapter } from './base.js';
+import type { AnalyticsEngineDataPoint } from '../types/index.js';
 import {
   realtimeEventSchema,
   type RealtimeEvent,
   type ServerContext,
 } from '../schemas/index.js';
-import { parseUserAgent } from '../utils/user-agent-parser';
-import { detectBot } from '../utils/bot-detection';
+import { parseUserAgent } from '../utils/user-agent-parser.js';
+import { detectBot } from '../utils/bot-detection.js';
 
 /**
  * Adapter for real-time analytics events

--- a/src/durable-objects/realtime-aggregator.ts
+++ b/src/durable-objects/realtime-aggregator.ts
@@ -2,9 +2,9 @@ import type {
   RealtimeEvent,
   RealtimeStats,
   AggregatedData,
-} from '../types/realtime';
-import { parseUserAgent } from '../utils/user-agent-parser';
-import { detectBot } from '../utils/bot-detection';
+} from '../types/realtime.js';
+import { parseUserAgent } from '../utils/user-agent-parser.js';
+import { detectBot } from '../utils/bot-detection.js';
 
 /**
  * Durable Object for real-time analytics aggregation

--- a/src/routes/realtime.ts
+++ b/src/routes/realtime.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
-import type { Env } from '../types/index';
-import { RealtimeAdapter } from '../adapters/realtime';
-import type { ServerContext, RealtimeEvent } from '../types/realtime';
+import type { Env } from '../types/index.js';
+import { RealtimeAdapter } from '../adapters/realtime.js';
+import type { ServerContext, RealtimeEvent } from '../types/realtime.js';
 
 const realtimeRouter = new Hono<{ Bindings: Env }>();
 const adapter = new RealtimeAdapter();

--- a/src/services/analytics-query.ts
+++ b/src/services/analytics-query.ts
@@ -377,17 +377,19 @@ export class AnalyticsQueryService {
         allValues.length
     );
 
-    timeseries.forEach((point) => {
-      const zScore = Math.abs((point.value - mean) / stdDev);
-      if (zScore > 2.5 && allValues.length > 10) {
-        anomalies.push({
-          timestamp: point.timestamp,
-          description: `Unusual activity detected: ${Math.round(point.value)} events`,
-          severity: zScore > 3 ? 'high' : 'medium',
-          value: point.value,
-        });
-      }
-    });
+    if (stdDev > 0) {
+      timeseries.forEach((point) => {
+        const zScore = Math.abs((point.value - mean) / stdDev);
+        if (zScore > 2.5 && allValues.length > 10) {
+          anomalies.push({
+            timestamp: point.timestamp,
+            description: `Unusual activity detected: ${Math.round(point.value)} events`,
+            severity: zScore > 3 ? 'high' : 'medium',
+            value: point.value,
+          });
+        }
+      });
+    }
 
     // Generate recommendations
     if (trends.length > 0 && trends[0]?.direction === 'up') {

--- a/src/services/project.ts
+++ b/src/services/project.ts
@@ -122,6 +122,18 @@ export async function listProjects(
 }
 
 /**
+ * Count total number of projects
+ * @param db D1 database binding
+ * @returns Total project count
+ */
+export async function countProjects(db: D1Database): Promise<number> {
+  const result = await db
+    .prepare('SELECT COUNT(*) as count FROM projects')
+    .first<{ count: number }>();
+  return result?.count ?? 0;
+}
+
+/**
  * Update last_used timestamp for a project
  * @param db D1 database binding
  * @param id Project ID

--- a/src/services/self-tracking.ts
+++ b/src/services/self-tracking.ts
@@ -74,8 +74,8 @@ export class SelfTrackingService {
     }
 
     // Create async write operation
-    const writePromise = Promise.resolve().then(() => {
-      const result = this.analyticsService.writeDataPoint(
+    const writePromise = Promise.resolve().then(async () => {
+      const result = await this.analyticsService.writeDataPoint(
         env,
         'SELF_TRACKING_ANALYTICS',
         this.adapter,

--- a/src/types/realtime.ts
+++ b/src/types/realtime.ts
@@ -248,13 +248,3 @@ export interface AggregatedData {
     visitor_id?: string;
   }>;
 }
-
-/**
- * Analytics Engine data point format
- * Reference: https://developers.cloudflare.com/analytics/analytics-engine/
- */
-export interface AnalyticsEngineDataPoint {
-  indexes?: string[]; // Max 1 index, max 96 bytes each
-  doubles?: number[]; // Numeric values
-  blobs?: string[]; // String values, max 5120 bytes each
-}

--- a/src/utils/fingerprint.ts
+++ b/src/utils/fingerprint.ts
@@ -1,4 +1,4 @@
-import type { FingerprintComponents, Fingerprint } from '../types/realtime';
+import type { FingerprintComponents, Fingerprint } from '../types/realtime.js';
 
 /**
  * Generate a privacy-respecting fingerprint from browser components

--- a/src/utils/route-handler.ts
+++ b/src/utils/route-handler.ts
@@ -11,14 +11,14 @@ export function createAnalyticsHandler<T>(
   adapter: DataAdapter<T>,
   analyticsService: AnalyticsEngineService
 ): {
-  handleGet: (c: Context<{ Bindings: Env }>) => Response;
+  handleGet: (c: Context<{ Bindings: Env }>) => Promise<Response>;
   handlePost: (c: Context<{ Bindings: Env }>) => Promise<Response>;
 } {
   return {
     /**
      * Handle GET requests with query parameters
      */
-    handleGet: (c: Context<{ Bindings: Env }>): Response => {
+    handleGet: async (c: Context<{ Bindings: Env }>): Promise<Response> => {
       const rawData = c.req.query() as Record<string, string | string[]>;
       const projectId = c.get('project_id');
 
@@ -33,7 +33,7 @@ export function createAnalyticsHandler<T>(
       const dataWithProject = projectId
         ? { ...rawData, project_id: projectId }
         : rawData;
-      const result = analyticsService.writeDataPoint(
+      const result = await analyticsService.writeDataPoint(
         c.env,
         dataset,
         adapter,
@@ -95,7 +95,7 @@ export function createAnalyticsHandler<T>(
         projectId && !Array.isArray(rawData)
           ? { ...rawData, project_id: projectId }
           : rawData;
-      const result = analyticsService.writeDataPoint(
+      const result = await analyticsService.writeDataPoint(
         c.env,
         dataset,
         adapter,

--- a/test/unit/services/project.test.ts
+++ b/test/unit/services/project.test.ts
@@ -6,6 +6,7 @@ import {
   createProject,
   getProject,
   listProjects,
+  countProjects,
   updateLastUsed,
 } from '../../../src/services/project.js';
 import type { ProjectCreateRequest } from '../../../src/types/index.js';
@@ -300,6 +301,43 @@ describe('listProjects', () => {
 
     expect(mockPrepare).toHaveBeenCalledWith(
       expect.stringContaining('ORDER BY created_at DESC')
+    );
+  });
+});
+
+describe('countProjects', () => {
+  it('should return total project count', async () => {
+    const { db, mockFirst } = createMockD1Database();
+    mockFirst.mockResolvedValue({ count: 42 });
+
+    const count = await countProjects(db);
+    expect(count).toBe(42);
+  });
+
+  it('should return 0 when no projects exist', async () => {
+    const { db, mockFirst } = createMockD1Database();
+    mockFirst.mockResolvedValue({ count: 0 });
+
+    const count = await countProjects(db);
+    expect(count).toBe(0);
+  });
+
+  it('should return 0 when result is null', async () => {
+    const { db, mockFirst } = createMockD1Database();
+    mockFirst.mockResolvedValue(null);
+
+    const count = await countProjects(db);
+    expect(count).toBe(0);
+  });
+
+  it('should use correct SQL COUNT query', async () => {
+    const { db, mockPrepare, mockFirst } = createMockD1Database();
+    mockFirst.mockResolvedValue({ count: 5 });
+
+    await countProjects(db);
+
+    expect(mockPrepare).toHaveBeenCalledWith(
+      'SELECT COUNT(*) as count FROM projects'
     );
   });
 });


### PR DESCRIPTION
## Summary

Pre-production codebase audit identified 6 bugs across the analytics pipeline. All fixes are non-breaking with 100% test coverage maintained (688 tests passing).

## Changes

- **Bug 1 — Duplicate type**: Removed duplicate `AnalyticsEngineDataPoint` interface from `types/realtime.ts`; realtime adapter imports from `types/index.js`
- **Bug 2 — Division by zero**: Guard `stdDev === 0` before anomaly z-score calculation — identical values caused `Infinity` zScore and false anomaly reports on every data point
- **Bug 3 — Busy-wait loop**: Replaced `while (Date.now() - start < delay)` with `await new Promise(r => setTimeout(r, delay))`; made `writeDataPoint` async — the sync loop blocks V8's event loop in Cloudflare edge runtime, starving I/O and `fetch()` calls
- **Bug 4 — Wrong pagination total**: Added `countProjects()` (SQL `COUNT(*)`) and replaced `total: projects.length` (page size) with actual DB total in the project list response
- **Bug 5 — parseInt radix**: Added explicit radix 10 and `|| default` NaN fallback to `limit`/`offset` parsing
- **Bug 6 — Import extensions**: Added `.js` to all bare local imports in `realtime.ts`, `realtime-aggregator.ts`, `routes/realtime.ts`, and `fingerprint.ts` for ESM compatibility

## Tests

- 28 test files, 688 tests — all passing
- `tsc --noEmit` — zero errors
- `eslint` — zero errors
- New tests: `countProjects` unit tests, stdDev=0 anomaly case, NaN param fallback, pagination total correctness

---
Generated with Claude Code

## Summary by Sourcery

Fix multiple analytics and projects API issues uncovered in a pre-production audit, including anomaly detection stability, non-blocking analytics writes, and accurate project pagination metadata.

Bug Fixes:
- Prevent division-by-zero in analytics anomaly detection when standard deviation is zero so identical values do not produce false anomalies.
- Make analytics write operations fully async with non-blocking retry backoff to avoid event loop starvation in the edge runtime.
- Return the true database-wide project count from the projects listing API instead of the page size.
- Parse pagination parameters with an explicit decimal radix and fall back to default limit/offset values when query parameters are NaN.
- Remove a duplicate AnalyticsEngineDataPoint type definition from realtime types to avoid type inconsistencies.
- Add missing .js extensions to local ESM imports for realtime and fingerprint modules to ensure runtime compatibility.

Enhancements:
- Add dedicated countProjects service and tests to encapsulate project counting logic and reuse it in the projects API.

Tests:
- Expand unit and E2E test coverage for analytics anomaly handling, project counting, pagination totals, NaN pagination parameter behavior, and async analytics writes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Projects API returns the database total for pagination (fetched concurrently) and uses robust default parsing for limit/offset
  * Anomaly detection no longer produces invalid results for uniform datasets (stdDev = 0)
  * POST route success message updated to "Data processed"

* **Improvements**
  * Analytics write operations now use proper asynchronous handling to improve reliability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->